### PR TITLE
feat: Persisting search & version filters in URL

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["angular.ng-template", "nrwl.angular-console"]
+  "recommendations": [
+    "angular.ng-template",
+    "esbenp.prettier-vscode",
+    "nrwl.angular-console"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,8 +1,7 @@
 import { ApplicationConfig } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideAnimations(), provideRouter(appRoutes)],
+  providers: [provideAnimations(), provideRouter([])],
 };

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,8 @@
 import { ApplicationConfig } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideAnimations()],
+  providers: [provideAnimations(), provideRouter(appRoutes)],
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,0 @@
-import { Route } from '@angular/router';
-import { AppComponent } from './app.component';
-
-export const appRoutes: Route[] = [
-  { path: '', component: AppComponent, pathMatch: 'full' },
-];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,0 +1,6 @@
+import { Route } from '@angular/router';
+import { AppComponent } from './app.component';
+
+export const appRoutes: Route[] = [
+  { path: '', component: AppComponent, pathMatch: 'full' },
+];

--- a/src/app/search.component.ts
+++ b/src/app/search.component.ts
@@ -1,5 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnInit,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';

--- a/src/app/search.component.ts
+++ b/src/app/search.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -69,7 +69,7 @@ import { StateService } from './state.service';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SearchComponent {
+export class SearchComponent implements OnInit {
   state = inject(StateService);
 
   searchControl = new FormControl<string>('', { nonNullable: true });
@@ -89,5 +89,9 @@ export class SearchComponent {
       .subscribe((value) => {
         this.state.searchFilter.set(value);
       });
+  }
+
+  ngOnInit() {
+    this.searchControl.setValue(this.state.searchFilter());
   }
 }

--- a/src/app/state.service.ts
+++ b/src/app/state.service.ts
@@ -47,8 +47,7 @@ export class StateService {
       .split(',')
       .map((v) => v.trim())
       .filter(Boolean);
-    const versions = maybeVersions.filter((v) => validVersions.includes(v));
-    return versions;
+    return maybeVersions.filter((v) => validVersions.includes(v));
   }
 
   constructor() {

--- a/src/app/state.service.ts
+++ b/src/app/state.service.ts
@@ -70,7 +70,7 @@ export class StateService {
       // Auto-update URL when state changes
       const searchFilter = this.searchFilter().trim();
       const versionsFilter = this.versionsToShow().join(',');
-      let queryParams: SearchQueryParams = {};
+      const queryParams: SearchQueryParams = {};
       if (searchFilter) {
         queryParams.search = searchFilter;
       }

--- a/src/app/state.service.ts
+++ b/src/app/state.service.ts
@@ -1,4 +1,5 @@
-import { computed, effect, Injectable, signal } from '@angular/core';
+import { Location, PlatformLocation } from '@angular/common';
+import { computed, effect, inject, Injectable, signal } from '@angular/core';
 import { LIBRARY_SUPPORT_DATA } from './libs.data';
 import { getAllAngularVersionsFromLibrarySupportData } from './utils';
 
@@ -28,9 +29,38 @@ export class StateService {
       .slice(0, 30); // always limit to 30 results
   });
 
+  location = inject(Location);
+  platformLocation = inject(PlatformLocation);
+
   constructor() {
     effect(() => console.log('versionsToShow', this.versionsToShow()));
     effect(() => console.log('data', this.filteredData()));
     effect(() => console.log('searchFilter', this.searchFilter()));
+
+    const url = new URL(this.platformLocation.href);
+    if (url.searchParams.has('search')) {
+      this.searchFilter.set(url.searchParams.get('search') || '');
+    }
+    if (url.searchParams.has('versions')) {
+      const maybeCSV = url.searchParams.get('versions') || '';
+      const maybeVersions = maybeCSV.split(',').map(v => v.trim()).filter(Boolean);
+      const versions = maybeVersions.filter((v) => ALL_ANGULAR_VERSIONS.includes(v));
+      this.versionsToShow.set(versions);
+    }
+
+    effect(() => {
+      const searchFilter = this.searchFilter().trim();
+      const versionsFilter = this.versionsToShow().join(',');
+      const params = new URLSearchParams();
+
+      if (searchFilter) {
+        params.set('search', searchFilter);
+      }
+      if (versionsFilter) {
+        params.set('versions', versionsFilter);
+      }
+
+      this.location.replaceState('', params.toString());
+    });
   }
 }

--- a/src/app/state.service.ts
+++ b/src/app/state.service.ts
@@ -43,8 +43,13 @@ export class StateService {
     }
     if (url.searchParams.has('versions')) {
       const maybeCSV = url.searchParams.get('versions') || '';
-      const maybeVersions = maybeCSV.split(',').map(v => v.trim()).filter(Boolean);
-      const versions = maybeVersions.filter((v) => ALL_ANGULAR_VERSIONS.includes(v));
+      const maybeVersions = maybeCSV
+        .split(',')
+        .map((v) => v.trim())
+        .filter(Boolean);
+      const versions = maybeVersions.filter((v) =>
+        ALL_ANGULAR_VERSIONS.includes(v),
+      );
       this.versionsToShow.set(versions);
     }
 

--- a/src/app/state.service.ts
+++ b/src/app/state.service.ts
@@ -1,7 +1,13 @@
-import { Location, PlatformLocation } from '@angular/common';
+import { PlatformLocation } from '@angular/common';
 import { computed, effect, inject, Injectable, signal } from '@angular/core';
+import { Router } from '@angular/router';
 import { LIBRARY_SUPPORT_DATA } from './libs.data';
 import { getAllAngularVersionsFromLibrarySupportData } from './utils';
+
+type SearchQueryParams = {
+  search?: string;
+  versions?: string;
+};
 
 const ALL_ANGULAR_VERSIONS =
   getAllAngularVersionsFromLibrarySupportData(LIBRARY_SUPPORT_DATA);
@@ -29,43 +35,50 @@ export class StateService {
       .slice(0, 30); // always limit to 30 results
   });
 
-  location = inject(Location);
   platformLocation = inject(PlatformLocation);
+  router = inject(Router);
+
+  sanitizeVersions(
+    unsafeInput: string | null,
+    validVersions: string[] = this.allAngularVersions,
+  ) {
+    const maybeCSV = unsafeInput || '';
+    const maybeVersions = maybeCSV
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
+    const versions = maybeVersions.filter((v) => validVersions.includes(v));
+    return versions;
+  }
 
   constructor() {
     effect(() => console.log('versionsToShow', this.versionsToShow()));
     effect(() => console.log('data', this.filteredData()));
     effect(() => console.log('searchFilter', this.searchFilter()));
 
+    // Initialize state from URL
     const url = new URL(this.platformLocation.href);
     if (url.searchParams.has('search')) {
       this.searchFilter.set(url.searchParams.get('search') || '');
     }
     if (url.searchParams.has('versions')) {
-      const maybeCSV = url.searchParams.get('versions') || '';
-      const maybeVersions = maybeCSV
-        .split(',')
-        .map((v) => v.trim())
-        .filter(Boolean);
-      const versions = maybeVersions.filter((v) =>
-        ALL_ANGULAR_VERSIONS.includes(v),
+      this.versionsToShow.set(
+        this.sanitizeVersions(url.searchParams.get('versions')),
       );
-      this.versionsToShow.set(versions);
     }
 
     effect(() => {
+      // Auto-update URL when state changes
       const searchFilter = this.searchFilter().trim();
       const versionsFilter = this.versionsToShow().join(',');
-      const params = new URLSearchParams();
-
+      let queryParams: SearchQueryParams = {};
       if (searchFilter) {
-        params.set('search', searchFilter);
+        queryParams.search = searchFilter;
       }
       if (versionsFilter) {
-        params.set('versions', versionsFilter);
+        queryParams.versions = versionsFilter;
       }
-
-      this.location.replaceState('', params.toString());
+      this.router.navigate([], { queryParams, replaceUrl: true });
     });
   }
 }


### PR DESCRIPTION
**Changes:**
- Persists search and versions filter in the URL.
- Input for the version filter from the URL is sanitized to include valid versions only. Invalid versions are silently excluded.

**Screenshot:**

![URL persists in Address bar](https://github.com/eneajaho/ngx-libs/assets/19947758/e5132ab6-5cdd-4ff2-93f3-adaa8116ee9d)

**Basic tests (manual):**
- Visit base URL. Default-selected versions should auto-populate.
- Change search and/or version filter. URL should auto-update.
- Remove the version filter from the URL manually. The default-selected version should auto-populate.
- Enter invalid/arbitrary key values in the URL. URL should silently exclude them.
- Enter invalid version values in the URL. URL should silently exclude them.

---

Closes #1