### PR TITLE
feat: matrix in a json file

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "test"]
+        "cacheableOperations": ["build", "test", "write-json"]
       }
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ngx-libs",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "^16.1.5",
         "@angular/cdk": "^16.1.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "nx serve",
-    "build": "nx build",
+    "build": "nx run-many --targets=build,write-json -p ngx-libs",
     "test": "nx test",
     "add-lib": "nx g plugin:new-lib",
     "postinstall": "npx simple-git-hooks"

--- a/project.json
+++ b/project.json
@@ -84,6 +84,13 @@
         ],
         "scripts": []
       }
+    },
+    "write-json": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "ts-node tools/src/write-json.ts dist/ngx-libs/assets/libs.json"
+      },
+      "dependsOn": ["build"]
     }
   }
 }

--- a/tools/src/write-json.ts
+++ b/tools/src/write-json.ts
@@ -1,0 +1,12 @@
+import * as fs from 'fs';
+import { LIBRARY_SUPPORT_DATA } from '../../src/app/libs.data';
+
+const outputPath = process.argv[2];
+
+if (!outputPath) {
+  console.error('No output path provided');
+  process.exit(1);
+}
+
+const data = JSON.stringify(LIBRARY_SUPPORT_DATA, undefined, 2);
+fs.writeFileSync(outputPath, data);

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  }
+}


### PR DESCRIPTION
Solves #43 

The json file can be fetched from the repo [https://raw.githubusercontent.com/chihab/ngx-libs/feat-json-matrix/libs.data.json](https://raw.githubusercontent.com/chihab/ngx-libs/feat-json-matrix/libs.data.json)

Could be also copied/moved and served as static asset from /assets/libs.data.json  https://ngx-libs.com/assets/libs.data.json

Maybe also have a JSON schema to validate the JSON file in the pipeline