### PR TITLE
bug: Fix incorrect GitHub link for rx-angular/state

### DIFF
--- a/src/app/libs.data.ts
+++ b/src/app/libs.data.ts
@@ -41,7 +41,7 @@ export const LIBRARY_SUPPORT_DATA: LibrarySupport[] = [
   {
     name: '@rx-angular/state',
     npmUrl: 'https://www.npmjs.com/package/@rx-angular/state',
-    githubUrl: 'https://github.com/rx-angular/rx-angular',
+    githubUrl: 'https://github.com/rx-angular/rx-angular/tree/main/libs/state',
     versionSupport: {
       '16': {
         libraryVersion: '16.0.0',


### PR DESCRIPTION
![image](https://github.com/eneajaho/ngx-libs/assets/19947758/f8ec1511-57a8-43fa-b40c-c01287e400ff)

---
Closes #71