### PR TITLE
fix: 🐛 add message when no package matches the filter

### DIFF
--- a/src/app/support-grid.component.ts
+++ b/src/app/support-grid.component.ts
@@ -17,81 +17,90 @@ import { StateService } from './services/state.service';
   selector: 'app-support-grid',
   template: `
     <div class="cards-grid">
-      <mat-card *ngFor="let lib of cardData(); trackBy: state.trackItems">
-        <mat-card-header>
-          <mat-card-title>{{ lib.name }}</mat-card-title>
-          <mat-card-subtitle>
-            <a mat-button color="primary" [href]="lib.npmUrl" target="_blank">
-              <img src="assets/npm.png" width="20" alt="Npm link" />
-              {{
-                lib.npmUrl
-                  | replaceString : 'https://www.npmjs.com/package/' : ''
-              }}
-            </a>
-            <a
-              mat-button
-              color="primary"
-              [href]="lib.githubUrl"
-              target="_blank"
-            >
-              <img src="assets/github.svg" width="12" alt="Github link" />
-              {{ lib.githubUrl | replaceString : 'https://github.com/' : '' }}
-            </a>
-          </mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content>
-          <table style="width:100%">
-            <tr>
-              <th>Angular Version</th>
-              <th>Support</th>
-              <th>Library Version</th>
-            </tr>
-            <tr
-              *ngFor="let item of lib.versionSupport; trackBy: state.trackItems"
-            >
-              <td>v{{ item.angularVersion }}</td>
-              <td>
-                <ng-container *ngIf="item.support === true">✅</ng-container>
-                <ng-container *ngIf="item.support === false">❌</ng-container>
-                <ng-container *ngIf="item.support === 'progress'">
-                  ⏳
-                </ng-container>
-                <ng-container *ngIf="item.support === 'partial'">
-                  🧪
-                </ng-container>
-              </td>
-              <td>
-                <a
-                  *ngIf="item.support === true"
-                  mat-button
-                  color="primary"
-                  [href]="item.link"
-                  target="_blank"
-                >
-                  <mat-icon>link</mat-icon>
-                  {{ item.libraryVersion }}
-                </a>
-                <ng-container *ngIf="item.support === 'partial'">
+      <ng-container *ngIf="cardData().length; else noFilterMatch">
+        <mat-card *ngFor="let lib of cardData(); trackBy: state.trackItems">
+          <mat-card-header>
+            <mat-card-title>{{ lib.name }}</mat-card-title>
+            <mat-card-subtitle>
+              <a mat-button color="primary" [href]="lib.npmUrl" target="_blank">
+                <img src="assets/npm.png" width="20" alt="Npm link" />
+                {{
+                  lib.npmUrl
+                    | replaceString : 'https://www.npmjs.com/package/' : ''
+                }}
+              </a>
+              <a
+                mat-button
+                color="primary"
+                [href]="lib.githubUrl"
+                target="_blank"
+              >
+                <img src="assets/github.svg" width="12" alt="Github link" />
+                {{ lib.githubUrl | replaceString : 'https://github.com/' : '' }}
+              </a>
+            </mat-card-subtitle>
+          </mat-card-header>
+          <mat-card-content>
+            <table style="width:100%">
+              <tr>
+                <th>Angular Version</th>
+                <th>Support</th>
+                <th>Library Version</th>
+              </tr>
+              <tr
+                *ngFor="
+                  let item of lib.versionSupport;
+                  trackBy: state.trackItems
+                "
+              >
+                <td>v{{ item.angularVersion }}</td>
+                <td>
+                  <ng-container *ngIf="item.support === true">✅</ng-container>
+                  <ng-container *ngIf="item.support === false">❌</ng-container>
+                  <ng-container *ngIf="item.support === 'progress'">
+                    ⏳
+                  </ng-container>
+                  <ng-container *ngIf="item.support === 'partial'">
+                    🧪
+                  </ng-container>
+                </td>
+                <td>
                   <a
-                    mat-flat-button
+                    *ngIf="item.support === true"
+                    mat-button
+                    color="primary"
                     [href]="item.link"
                     target="_blank"
-                    [matTooltip]="item.note || ''"
                   >
-                    Partial ({{ item.libraryVersion }})
+                    <mat-icon>link</mat-icon>
+                    {{ item.libraryVersion }}
                   </a>
-                </ng-container>
-                <ng-container *ngIf="item.support === false">
-                  Not supported
-                </ng-container>
-                <ng-container *ngIf="item.support === 'progress'">
-                  In progress
-                </ng-container>
-              </td>
-            </tr>
-          </table>
-        </mat-card-content>
-      </mat-card>
+                  <ng-container *ngIf="item.support === 'partial'">
+                    <a
+                      mat-flat-button
+                      [href]="item.link"
+                      target="_blank"
+                      [matTooltip]="item.note || ''"
+                    >
+                      Partial ({{ item.libraryVersion }})
+                    </a>
+                  </ng-container>
+                  <ng-container *ngIf="item.support === false">
+                    Not supported
+                  </ng-container>
+                  <ng-container *ngIf="item.support === 'progress'">
+                    In progress
+                  </ng-container>
+                </td>
+              </tr>
+            </table>
+          </mat-card-content>
+        </mat-card>
+      </ng-container>
+
+      <ng-template #noFilterMatch>
+        <p>No package matching the filter "{{ state.searchFilter() }}" 🫤</p>
+      </ng-template>
     </div>
   `,
   standalone: true,
@@ -110,6 +119,17 @@ import { StateService } from './services/state.service';
         grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
         grid-gap: 1rem;
         margin-bottom: 1rem;
+      }
+
+      p {
+        border: 1px solid rgba(0, 0, 0, 0.12);
+        margin: 0;
+        padding: 1rem;
+        text-align: center;
+        grid-column: 1 / -1;
+        box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2),
+          0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+          0px 1px 5px 0px rgba(0, 0, 0, 0.12);
       }
     `,
   ],

--- a/src/app/support-table.component.ts
+++ b/src/app/support-table.component.ts
@@ -123,6 +123,13 @@ import { StateService } from './services/state.service';
 
         <tr mat-header-row *matHeaderRowDef="displayedColumns()"></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumns()"></tr>
+
+        <!-- Row shown when there is no matching data. -->
+        <tr class="mat-row" *matNoDataRow>
+          <td class="mat-cell" colspan="7">
+            No package matching the filter "{{ state.searchFilter() }}" 🫤
+          </td>
+        </tr>
       </table>
     </div>
 
@@ -164,6 +171,11 @@ import { StateService } from './services/state.service';
 
       .mat-mdc-row:hover .mat-mdc-cell {
         background-color: #f5f5f5;
+      }
+
+      .mat-mdc-no-data-row td {
+        padding: 1rem;
+        text-align: center;
       }
     `,
   ],


### PR DESCRIPTION
When searching for packages, add the message when package cannot be matched for that specific filter.

✅ Closes: #106