### PR TITLE
Update ngx-toastr and rx-angular to Support Angular upgarde versions

### DIFF
--- a/src/assets/library-support-data.json
+++ b/src/assets/library-support-data.json
@@ -44,7 +44,9 @@
         "link": "https://github.com/scttcper/ngx-toastr/releases/tag/v18.0.0"
       },
       "18": {
-        "support": "https://github.com/scttcper/ngx-toastr/tree/v19.0.0"
+        "libraryVersion": "v19.0.0",
+        "support": true,
+        "link": "https://github.com/scttcper/ngx-toastr/releases/tag/v19.0.0"
       }
     },
     "automated": true
@@ -87,10 +89,14 @@
         "link": "https://github.com/rx-angular/rx-angular/releases/tag/state%4016.0.0"
       },
       "17": {
-        "support": "partial"
+        "libraryVersion": "17.0.0",
+        "support": true,
+        "link": "https://github.com/rx-angular/rx-angular/releases/tag/state%4017.0.0"
       },
       "18": {
-        "support": "partial"
+        "libraryVersion": "18.0.0",
+        "support": true,
+        "link": "https://github.com/rx-angular/rx-angular/releases/tag/state%4018.0.0"
       }
     },
     "automated": true

--- a/src/assets/library-support-data.json
+++ b/src/assets/library-support-data.json
@@ -44,7 +44,7 @@
         "link": "https://github.com/scttcper/ngx-toastr/releases/tag/v18.0.0"
       },
       "18": {
-        "support": "partial"
+        "support": "https://github.com/scttcper/ngx-toastr/tree/v19.0.0"
       }
     },
     "automated": true


### PR DESCRIPTION
This PR updates 2 packages to support latest major version of angular for couple of libs. Which has provided support to ng 17 and ng 18

- ngx-toastr
  - v17 ✅  
![Screenshot 2024-06-12 at 12 44 51 PM](https://github.com/eneajaho/ngx-libs/assets/17727069/71ffb7ff-11c4-4409-a909-465f8cbf54a5)

- rx-angular/state
  - v17 ✅ 
  -  v18  ✅ 
![Screenshot 2024-06-12 at 12 41 36 PM](https://github.com/eneajaho/ngx-libs/assets/17727069/984ea99a-ace9-460e-b714-db4e441697bf)
